### PR TITLE
Update fpm manifest to override defaults assumed since v.0.8.x

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -6,6 +6,11 @@ description = "Modern Fortran interface to part of ODEPACK"
 homepage = "https://github.com/Nicholaswogan/odepack"
 keywords = ["ODE"]
 
+[fortran]
+source-form = "default"
+implicit-external = true
+implicit-typing = true
+
 [library]
 source-dir = "src"
 


### PR DESCRIPTION
fpm v.0.8.x introduced default settings regarding implicit types, interfaces and source form. See [fpm doc](https://fpm.fortran-lang.org/spec/manifest.html#fortran-features).

To use your version of odepack with fpm>=0.8.x, the manifest needs to be updated as per this PR.

Se also [fpm #956](https://github.com/fortran-lang/fpm/issues/956).